### PR TITLE
add nixos/modules/misc

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -33,6 +33,11 @@ jobs:
     - name: Procure git-filter-repo from nixpkgs
       run: "nix-env -i git-filter-repo -f '<nixpkgs>'"
 
+    - name: Filter nixpkgs on ./nixos/modules/misc
+      run: |
+        git clone ./nixpkgs nixpkgs-modules
+        cd ./nixpkgs-modules
+        git filter-repo --path nixos/modules/misc --force
 
     - name: Filter nixpkgs on ./lib
       run: |
@@ -43,10 +48,13 @@ jobs:
       run: |
         cd ./nixpkgs-lib
         git remote add other ../nixpkgs/
+        git remote add modules ../nixpkgs-modules/
         git fetch other master
+        git fetch modules master
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
         git merge -X theirs --allow-unrelated-histories other/master
+        git merge -X theirs --allow-unrelated-histories modules/master
 
     - name: Push changes
       uses: ad-m/github-push-action@master


### PR DESCRIPTION
To make use of some module-related lib functions such as `mkRemovedOptionModule`, it's necessary to import/include files like [`nixos/modules/misc/assertions.nix`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/misc/assertions.nix). I [whitelist these files in my own filtered nixpkgs](https://github.com/arcnmx/nixpkgs-lib/blob/af900fa0c3af3988619bac403b7d19eb81ef4749/generate/filter.sh#L3-L8), and would need the same to be done here in order to be able to use it instead.