### PR TITLE
nixpkgs.lib: Include `.version`

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Filter nixpkgs on ./lib
       run: |
         cd ./nixpkgs
-        git filter-repo --path lib --force
+        git filter-repo --path .version --path .version-suffix --path lib --force
 
     - name: Update nixpkgs.lib
       run: |


### PR DESCRIPTION
Used by `release`, `version`, and `isInOldestRelease`.

I know <https://github.com/nix-community/nixpkgs.lib/pull/1> already was refused, but I think this is valid for versioning `lib` itself. Example use: <https://github.com/hercules-ci/flake-parts/blob/70d1b51a85170b46b57a2ad62308501651daa5c1/lib.nix#L214-L229>

```nix
  # A best effort, lenient estimate. Please use a recent nixpkgs lib if you
  # override it at all.
  minVersion = "22.05";


in


if builtins.compareVersions lib.version minVersion < 0
then
  abort ''
    The nixpkgs-lib dependency of flake-parts was overridden but is too old.
    The minimum supported version of nixpkgs-lib is ${minVersion},
    but the actual version is ${lib.version}${revInfo}.
  ''
else

  flake-parts-lib
```