### PR TITLE
.github/workflows/update: add "maintainers/"

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,10 +24,10 @@ jobs:
     - name: Install git-filter-repo
       run: pip install --user git-filter-repo
 
-    - name: Filter nixpkgs for lib only
+    - name: Filter nixpkgs
       run: |
         cd nixpkgs.git
-        ~/.local/bin/git-filter-repo --path lib --path COPYING --force
+        ~/.local/bin/git-filter-repo --path lib --path maintainers --path COPYING --force
 
     - name: Merge lib updates into nixpkgs-lib
       run: |


### PR DESCRIPTION
The `maintainers` directory is used in `./lib/default`: [https://github.com/NixOS/nixpkgs/blob/6a6707f4dd2a8f9b41e40b2675db7c08952b9570/lib/default.nix#L65-L66](https://github.com/NixOS/nixpkgs/blob/6a6707f4dd2a8f9b41e40b2675db7c08952b9570/lib/default.nix#L65-L66)

It might make sense to exclude the `./maintainers/scripts/` directory, since it contains quite a lot of files that are unrelated to `lib`.
